### PR TITLE
[#1] Offerings Section - columns text aligned to left

### DIFF
--- a/source/stylesheets/style.css.scss
+++ b/source/stylesheets/style.css.scss
@@ -39,6 +39,7 @@
 .extract {
   margin: 1em auto;
   width: 90%;
+  text-align: justify;
 }
 
 .about {


### PR DESCRIPTION
In the offerings section with three columns, each having their text aligned to left by default, does not give an intuitive feeling to read in comparison to the scenario if they where aligned justified.

Before
<img width="1192" alt="before" src="https://cloud.githubusercontent.com/assets/6065869/9198029/bad13138-4056-11e5-91b2-b64d40f239de.png">

After
<img width="1191" alt="after" src="https://cloud.githubusercontent.com/assets/6065869/9198031/bda62d32-4056-11e5-8faf-b5694ef592e6.png">

Suggestion:  text-align: justify
